### PR TITLE
support redmine-5.1

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,7 +1,13 @@
 require 'redmine'
 
-reloader = defined?(ActiveSupport::Reloader) ? ActiveSupport::Reloader : ActionDispatch::Reloader
-reloader.to_prepare do
+register_after_redmine_initialize_proc =
+  if Redmine::VERSION::MAJOR >= 5
+    Rails.application.config.public_method(:after_initialize)
+  else
+    reloader = defined?(ActiveSupport::Reloader) ? ActiveSupport::Reloader : ActionDispatch::Reloader
+    reloader.public_method(:to_prepare)
+  end
+register_after_redmine_initialize_proc.call do
   require_dependency 'issue'
   # Guards against including the module multiple time (like in tests)
   # and registering multiple callbacks


### PR DESCRIPTION
### before pull-request

```console
root@aeb7af15062f:/opt/app# bin/rails console --environment=production
Loading production environment (Rails 6.1.6)
irb(main):001:0> Issue.included_modules.include? RedmineAutoPercent::IssuePatch
=> false
```

### after pull-request

```console
root@aeb7af15062f:/opt/app# bin/rails console --environment=production
Loading production environment (Rails 6.1.6)
irb(main):001:0> Issue.included_modules.include? RedmineAutoPercent::IssuePatch
=> true
```

### tested Redmine version

```
[4] pry(main)> Redmine::VERSION::STRING
=> "5.0.1.stable"
```
